### PR TITLE
Integrate all components

### DIFF
--- a/archive-server/Dockerfile
+++ b/archive-server/Dockerfile
@@ -7,8 +7,6 @@ RUN apt-get update && apt-get install -y archive-server patch git
 
 EXPOSE      3031 3032
 
-VOLUME /data/archive-server
-
 ADD ./run.sh /run.sh
 RUN chmod +x /run.sh
 

--- a/archive-server/run.sh
+++ b/archive-server/run.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+mkdir -p /data/archive-server/archives
 source /data/archive-server/archive-server
 /usr/bin/archive-server $ARCHIVE_SERVER_OPTS

--- a/consul-template/Dockerfile
+++ b/consul-template/Dockerfile
@@ -15,11 +15,6 @@ ADD ./gandalf.ctmpl /tmp/gandalf.ctmpl
 ADD ./pre-receive.ctmpl /tmp/pre-receive.ctmpl
 ADD ./archive-server.ctmpl /tmp/archive-server.ctmpl
 
-VOLUME /data/tsuru
-VOLUME /data/router
-VOLUME /data/gandalf
-VOLUME /data/archive-server
-
 ENV DOCKER_HOST unix:///tmp/docker.sock
 
 LABEL "name"="consul-template"

--- a/consul-template/Dockerfile
+++ b/consul-template/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:14.04
 
 MAINTAINER tsuru <tsuru@corp.globo.com>
-ADD https://github.com/hashicorp/consul-template/releases/download/v0.10.0/consul-template_0.10.0_linux_amd64.tar.gz /tmp/
-RUN tar -zxf /tmp/consul-template_0.10.0_linux_amd64.tar.gz -C /bin/ --strip-components=1 && rm -rf /tmp/consul-template_0.10.0_linux_amd64.tar.gz
+ADD https://github.com/hashicorp/consul-template/releases/download/v0.11.0/consul_template_0.11.0_linux_amd64.zip /tmp/
+RUN apt-get install -y unzip
+RUN unzip /tmp/consul_template_0.11.0_linux_amd64.zip -d /bin && rm -rf /tmp/consul-template_0.11.0_linux_amd64.tar.gz
 
 ADD https://get.docker.com/builds/Linux/x86_64/docker-latest /bin/docker
 RUN chmod +x /bin/docker

--- a/consul-template/consul-template.conf
+++ b/consul-template/consul-template.conf
@@ -30,6 +30,7 @@ template {
   source = "/tmp/pre-receive.ctmpl"
   destination = "/data/gandalf/template/hooks/pre-receive"
   command = "docker ps -qf name=gandalf |xargs docker restart ;:"
+  perms = 0755
 }
 
 template {

--- a/consul-template/gandalf.ctmpl
+++ b/consul-template/gandalf.ctmpl
@@ -1,7 +1,7 @@
 bin-path: /usr/bin/gandalf-ssh
 
 log:
-  file: /var/log/gandalf.log
+  file: /data/gandalf/log/gandalf.log
   disable-syslog: true
 
 authorized-keys-path: /home/git/.ssh/authorized_keys

--- a/consul-template/tsuru.ctmpl
+++ b/consul-template/tsuru.ctmpl
@@ -86,7 +86,7 @@ routers:{{range ls "tsuru/routers"}}
   {{.Value}}{{else}}
   hipache:
     type: hipache
-    domain: router-hipache.service.consul
+    domain: {{ if key "hipache/domain" }}{{ key "hipache/domain" }}{{ else }}router-hipache.service.consul{{ end }}
     redis-server: redis.service.consul:6379{{end}}
 
 {{if key "tsuru/iaas/default"}}

--- a/gandalf/Dockerfile
+++ b/gandalf/Dockerfile
@@ -20,8 +20,6 @@ ENV DOCKER_HOST unix:///tmp/docker.sock
 
 EXPOSE      8001
 
-VOLUME /data/gandalf
-
 LABEL name="gandalf"
 
 RUN chown -R git:git /data/gandalf

--- a/gandalf/Dockerfile
+++ b/gandalf/Dockerfile
@@ -22,6 +22,4 @@ EXPOSE      8001
 
 LABEL name="gandalf"
 
-RUN chown -R git:git /data/gandalf
-
 ENTRYPOINT /run.sh

--- a/gandalf/run.sh
+++ b/gandalf/run.sh
@@ -10,10 +10,10 @@ if [ "$TSURU_TOKEN" == "" ]; then
   /bin/docker run -v /data/tsuru:/data/tsuru tsuru/tsuru-api gandalf-sync --config=/data/tsuru/tsuru.conf
   /usr/sbin/sshd -D &
   /usr/sbin/rsyslogd &
-  /usr/bin/gandalf-server -config=/data/gandalf/gandalf.conf
+  su - git -c "/usr/bin/gandalf-server -config=/data/gandalf/gandalf.conf"
 else
   /bin/docker run -v /data/tsuru:/data/tsuru tsuru/tsuru-api gandalf-sync --config=/data/tsuru/tsuru.conf
   /usr/sbin/sshd -D &
   /usr/sbin/rsyslogd &
-  /usr/bin/gandalf-server -config=/data/gandalf/gandalf.conf
+  su - git -c "/usr/bin/gandalf-server -config=/data/gandalf/gandalf.conf"
 fi

--- a/gandalf/run.sh
+++ b/gandalf/run.sh
@@ -2,6 +2,7 @@
 
 TSURU_TOKEN=`curl -s http://consul.service.consul:8500/v1/kv/tsuru/token?raw`
 
+mkdir -p /data/gandalf/log
 chown -R git:git /data/gandalf
 
 if [ "$TSURU_TOKEN" == "" ]; then

--- a/gandalf/run.sh
+++ b/gandalf/run.sh
@@ -2,6 +2,8 @@
 
 TSURU_TOKEN=`curl -s http://consul.service.consul:8500/v1/kv/tsuru/token?raw`
 
+chown -R git:git /data/gandalf
+
 if [ "$TSURU_TOKEN" == "" ]; then
   TSURU_TOKEN=`/bin/docker run -v /data/tsuru:/data/tsuru tsuru/tsuru-api token --config=/data/tsuru/tsuru.conf`
   curl -s -X PUT -d $TSURU_TOKEN http://consul.service.consul:8500/v1/kv/tsuru/token

--- a/router-hipache/Dockerfile
+++ b/router-hipache/Dockerfile
@@ -6,6 +6,8 @@ RUN echo "deb http://ppa.launchpad.net/tsuru/ppa/ubuntu trusty main"  > /etc/apt
 RUN apt-get update
 RUN apt-get install -y node-hipache redis-server patch
 
+RUN echo DAEMON_ARGS=/data/router/redis.conf > /etc/default/redis-server
+
 EXPOSE      8080
 
 ADD ./run.sh /bin/run.sh

--- a/router-hipache/Dockerfile
+++ b/router-hipache/Dockerfile
@@ -8,8 +8,6 @@ RUN apt-get install -y node-hipache redis-server patch
 
 EXPOSE      8080
 
-VOLUME /data/router
-
 ADD ./run.sh /bin/run.sh
 RUN chmod +x /bin/run.sh
 

--- a/tsuru-api/Dockerfile
+++ b/tsuru-api/Dockerfile
@@ -11,8 +11,6 @@ ADD ./tsuru-defaults /etc/default/tsuru-server
 RUN touch /var/log/tsuru.log
 RUN chown tsuru:tsuru /var/log/tsuru.log
 
-VOLUME /data/tsuru
-
 LABEL name="tsuru-api"
 
 ENTRYPOINT ["/usr/bin/tsurud"]


### PR DESCRIPTION
## What

This PR contains several fixes to integrate all Tsuru components. This allows to deploy and run an application successfully inside Tsuru.
## How to review
- Create a local docker daemon
- Build local docker images
- Install Tsuru server components
- Create and register a generic docker node
- Deploy a sample application

It is recommended to use https://github.com/saliceti/tsuru-machine that will automate much of the process using `make dev` and `make test`
