### PR TITLE
Remove consul template hard coded ip

### DIFF
--- a/consul-template/Dockerfile
+++ b/consul-template/Dockerfile
@@ -20,4 +20,4 @@ ENV DOCKER_HOST unix:///tmp/docker.sock
 
 LABEL "name"="consul-template"
 
-ENTRYPOINT /bin/consul-template -config /etc/consul-template.conf
+ENTRYPOINT ["/bin/consul-template", "-config", "/etc/consul-template.conf"]

--- a/consul-template/consul-template.conf
+++ b/consul-template/consul-template.conf
@@ -1,4 +1,3 @@
-consul = "172.17.42.1:8500"
 retry = "3s"
 log_level = "info"
 

--- a/doc/single_host_deploy.md
+++ b/doc/single_host_deploy.md
@@ -54,7 +54,7 @@
     -v /data/router:/data/router \
     -v /data/gandalf:/data/gandalf \
     -v /data/archive-server:/data/archive-server \
-    tsuru/consul-template
+    tsuru/consul-template -consul `docker-machine ip docker01`:8500
   ```
 
 ## Start tsuru

--- a/gandalf/Dockerfile
+++ b/gandalf/Dockerfile
@@ -22,4 +22,4 @@ EXPOSE      8001
 
 LABEL name="gandalf"
 
-ENTRYPOINT /run.sh
+ENTRYPOINT ["/run.sh"]

--- a/router-hipache/Dockerfile
+++ b/router-hipache/Dockerfile
@@ -13,4 +13,4 @@ EXPOSE      8080
 ADD ./run.sh /bin/run.sh
 RUN chmod +x /bin/run.sh
 
-ENTRYPOINT /bin/run.sh
+ENTRYPOINT ["/bin/run.sh"]

--- a/router-hipache/run.sh
+++ b/router-hipache/run.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
+
 /etc/init.d/redis-server start
 /usr/bin/hipache --config /data/router/hipache.conf


### PR DESCRIPTION
IP allocation has changed in Docker 1.9 and we can't rely on the usual `172.17.42.1` anymore.

This PR: 
- Removes the hard coded IP from consul template config file. This forces to pass it as argument
- Replaces ENTRYPOINT commands in "shell" form with "exec" form. This allows passing arguments. It also has the benefit of not running the process as `sh` subprocess, so it receives signals directly.
- Updates Readme
