### PR TITLE
Restart router-hipache when redis config changes

### DIFF
--- a/consul-template/consul-template.conf
+++ b/consul-template/consul-template.conf
@@ -16,7 +16,7 @@ template {
 template {
   source = "/tmp/redis.ctmpl"
   destination = "/data/router/redis.conf"
-  command = "docker ps -qf name=redis |xargs docker restart ;:"
+  command = "docker ps -qf name=router |xargs docker restart ;:"
 }
 
 template {


### PR DESCRIPTION
`consul-template` was configured to restart `redis` when the redis.conf file changed. However, 
this config file is not for the redis container, it is for redis inside router-hipache container.
Therefore we must restart the router-hipache container instead.
