### PR TITLE
Store gandalf keys outside of the container

### DIFF
--- a/consul-template/gandalf.ctmpl
+++ b/consul-template/gandalf.ctmpl
@@ -4,7 +4,7 @@ log:
   file: /data/gandalf/log/gandalf.log
   disable-syslog: true
 
-authorized-keys-path: /home/git/.ssh/authorized_keys
+authorized-keys-path: /data/gandalf/ssh/authorized_keys
 
 # MongoDB connection settings. By default, Gandalf will connect on localhost
 # using the "gandalf" database. Uncomment and change to customize.

--- a/gandalf/Dockerfile
+++ b/gandalf/Dockerfile
@@ -9,6 +9,7 @@ ADD ./git-daemon /etc/default/git-daemon
 ADD ./run.sh /run.sh
 RUN chmod +x /run.sh
 RUN mkdir /var/run/sshd
+RUN echo AuthorizedKeysFile /data/gandalf/ssh/authorized_keys >> /etc/ssh/sshd_config
 RUN rm -f /etc/gandalf.conf
 RUN ln -s /data/gandalf/gandalf.conf /etc/gandalf.conf
 

--- a/gandalf/run.sh
+++ b/gandalf/run.sh
@@ -2,7 +2,7 @@
 
 TSURU_TOKEN=`curl -s http://consul.service.consul:8500/v1/kv/tsuru/token?raw`
 
-mkdir -p /data/gandalf/log
+mkdir -p /data/gandalf/log /data/gandalf/ssh
 chown -R git:git /data/gandalf
 
 if [ "$TSURU_TOKEN" == "" ]; then

--- a/gandalf/run.sh
+++ b/gandalf/run.sh
@@ -10,11 +10,11 @@ if [ "$TSURU_TOKEN" == "" ]; then
   curl -s -X PUT -d $TSURU_TOKEN http://consul.service.consul:8500/v1/kv/tsuru/token
   /bin/docker run -v /data/tsuru:/data/tsuru tsuru/tsuru-api gandalf-sync --config=/data/tsuru/tsuru.conf
   /usr/sbin/sshd
-  /usr/sbin/rsyslogd &
+  /usr/sbin/rsyslogd
   su - git -c "/usr/bin/gandalf-server -config=/data/gandalf/gandalf.conf"
 else
   /bin/docker run -v /data/tsuru:/data/tsuru tsuru/tsuru-api gandalf-sync --config=/data/tsuru/tsuru.conf
   /usr/sbin/sshd
-  /usr/sbin/rsyslogd &
+  /usr/sbin/rsyslogd
   su - git -c "/usr/bin/gandalf-server -config=/data/gandalf/gandalf.conf"
 fi

--- a/gandalf/run.sh
+++ b/gandalf/run.sh
@@ -9,12 +9,12 @@ if [ "$TSURU_TOKEN" == "" ]; then
   TSURU_TOKEN=`/bin/docker run -v /data/tsuru:/data/tsuru tsuru/tsuru-api token --config=/data/tsuru/tsuru.conf`
   curl -s -X PUT -d $TSURU_TOKEN http://consul.service.consul:8500/v1/kv/tsuru/token
   /bin/docker run -v /data/tsuru:/data/tsuru tsuru/tsuru-api gandalf-sync --config=/data/tsuru/tsuru.conf
-  /usr/sbin/sshd -D &
+  /usr/sbin/sshd
   /usr/sbin/rsyslogd &
   su - git -c "/usr/bin/gandalf-server -config=/data/gandalf/gandalf.conf"
 else
   /bin/docker run -v /data/tsuru:/data/tsuru tsuru/tsuru-api gandalf-sync --config=/data/tsuru/tsuru.conf
-  /usr/sbin/sshd -D &
+  /usr/sbin/sshd
   /usr/sbin/rsyslogd &
   su - git -c "/usr/bin/gandalf-server -config=/data/gandalf/gandalf.conf"
 fi


### PR DESCRIPTION
At the moment the SSH public keys are lost when the container is recreated. But tsuru-api still thinks they are present and this causes confusion.
Storing in /data/gandalf/ssh solves the issue.
