### PR TITLE
Write tsuru-api logs to standard error

### DIFF
--- a/consul-template/tsuru.ctmpl
+++ b/consul-template/tsuru.ctmpl
@@ -28,10 +28,8 @@ git:
   api-server: {{if key "tsuru/git/api-server"}}{{key "tsuru/git/api-server"}}{{else}}http://gandalf.service.consul:8001{{end}}
 
 log:
-  file: {{if key "tsuru/log/file"}}{{key "tsuru/log/file"}}{{else}}/var/log/tsuru.log{{end}}
-  disable-syslog: {{if key "tsuru/log/disable-syslog"}}{{key "tsuru/log/disable-syslog"}}{{else}}true{{end}}
-  syslog-tag: {{if key "tsuru/log/syslog-tag"}}{{key "tsuru/log/syslog-tag"}}{{else}}tsr{{end}}
-  use-stderr: {{if key "tsuru/log/use-stderr"}}{{key "tsuru/log/use-stderr"}}{{else}}false{{end}}
+  disable-syslog: true
+  use-stderr: true
 
 auth:
   scheme: {{if key "tsuru/auth/scheme"}}{{key "tsuru/auth/scheme"}}{{else}}native{{end}}


### PR DESCRIPTION
This removes other configurations as in docker world we want the processes to log to stdout or stderr so we can read them via `docker logs`.
This also allows to configure docker so it sends the logs to other logging destination.
