### PR TITLE
Gandalf log to stderr

### DIFF
--- a/consul-template/gandalf.ctmpl
+++ b/consul-template/gandalf.ctmpl
@@ -1,8 +1,8 @@
 bin-path: /usr/bin/gandalf-ssh
 
 log:
-  file: /data/gandalf/log/gandalf.log
   disable-syslog: true
+  use-stderr: true
 
 authorized-keys-path: /data/gandalf/ssh/authorized_keys
 

--- a/consul-template/gandalf.ctmpl
+++ b/consul-template/gandalf.ctmpl
@@ -4,6 +4,8 @@ log:
   disable-syslog: true
   use-stderr: true
 
+debug: {{if key "gandalf/debug"}}{{key "gandalf/debug"}}{{else}}false{{end}}
+
 authorized-keys-path: /data/gandalf/ssh/authorized_keys
 
 # MongoDB connection settings. By default, Gandalf will connect on localhost


### PR DESCRIPTION
- Log to standard error instead of file so we can see the gandalf web logs via `docker logs gandalf`
- Add debug option

Note: this doesn't change the logs of gandalf-ssh which still go to syslog
